### PR TITLE
fix: escape non-ID_Start characters (e.g., digits) in initial position

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,5 +16,5 @@ export default function toValidIdentifier(value) {
 	}
 
 	return value.replaceAll(/(?<!^)\P{ID_Continue}/gu, encodeCodePoint)
-		.replaceAll(/^\P{ID_Start}/gu, encodeCodePoint);
+		.replaceAll(/^[^_\p{ID_Start}]/gu, encodeCodePoint);
 }

--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@ import base62 from '@sindresorhus/base62';
 
 const reservedIdentifiers = reservedIdentifiers_({includeGlobalProperties: true});
 
+const encodeCodePoint = x => `$${base62.encodeInteger(x.codePointAt(0))}$`;
+
 export default function toValidIdentifier(value) {
 	if (typeof value !== 'string') {
 		throw new TypeError(`Expected a string, got \`${typeof value}\`.`);
@@ -13,5 +15,6 @@ export default function toValidIdentifier(value) {
 		return `$_${value}$`;
 	}
 
-	return value.replaceAll(/\P{ID_Continue}/gu, x => `$${base62.encodeInteger(x.codePointAt(0))}$`);
+	return value.replaceAll(/(?<!^)\P{ID_Continue}/gu, encodeCodePoint)
+		.replaceAll(/^\P{ID_Start}/gu, encodeCodePoint);
 }

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ import toValidIdentifier from './index.js';
 test('main', t => {
 	t.is(toValidIdentifier('foo'), 'foo');
 	t.is(toValidIdentifier('$foo'), '$a$foo');
-	t.is(toValidIdentifier('_foo'), '$1X$foo');
+	t.is(toValidIdentifier('_foo'), '_foo');
 	t.is(toValidIdentifier('9foo'), '$v$foo');
 	t.is(toValidIdentifier('foo-bar'), 'foo$j$bar');
 	t.is(toValidIdentifier('null'), '$_null$');
@@ -12,4 +12,6 @@ test('main', t => {
 	t.is(toValidIdentifier('$'), '$a$');
 	t.is(toValidIdentifier(''), '');
 	t.is(toValidIdentifier('🦄'), '$XfI$');
+	t.is(toValidIdentifier('_'), '_');
+	t.is(toValidIdentifier('foo_bar'), 'foo_bar');
 });

--- a/test.js
+++ b/test.js
@@ -4,6 +4,8 @@ import toValidIdentifier from './index.js';
 test('main', t => {
 	t.is(toValidIdentifier('foo'), 'foo');
 	t.is(toValidIdentifier('$foo'), '$a$foo');
+	t.is(toValidIdentifier('_foo'), '$1X$foo');
+	t.is(toValidIdentifier('9foo'), '$v$foo');
 	t.is(toValidIdentifier('foo-bar'), 'foo$j$bar');
 	t.is(toValidIdentifier('null'), '$_null$');
 	t.is(toValidIdentifier('undefined'), '$_undefined$');


### PR DESCRIPTION
Non-ID_Start characters require their own escaping in initial position (e.g., digits cannot begin an identifier).
